### PR TITLE
add (>.) :: Lens a b -> Lens b c -> Lens a c

### DIFF
--- a/src/Data/Lens/Light/Core.hs
+++ b/src/Data/Lens/Light/Core.hs
@@ -53,9 +53,20 @@ modL' l f a =
     (setx, x) -> setx $! f x
 
 -- | Infix version of 'getL' (with the reverse order of the arguments)
-infixl 9 ^.
+infixl 8 ^.
 (^.) :: b -> Lens b c -> c
 (^.) = flip getL
+
+infixl 9 >.
+(>.) :: Lens a b -> Lens b c -> Lens a c
+f >. g = Lens $ \ x ->
+    let
+      (ym, y) = runLens f x
+      (zm, z) = runLens g y
+    in
+      ( ym . zm
+      , z
+      )
 
 -- | Convert a lens to its van Laarhoven representation
 vanLaarhoven :: Functor f => Lens a b -> (b -> f b) -> (a -> f a)

--- a/src/Data/Lens/Light/Core.hs
+++ b/src/Data/Lens/Light/Core.hs
@@ -60,13 +60,13 @@ infixl 8 ^.
 infixl 9 >.
 (>.) :: Lens a b -> Lens b c -> Lens a c
 f >. g = Lens $ \ x ->
-    let
-      (ym, y) = runLens f x
-      (zm, z) = runLens g y
-    in
-      ( ym . zm
-      , z
-      )
+  let
+    (ym, y) = runLens f x
+    (zm, z) = runLens g y
+  in
+    ( ym . zm
+    , z
+    )
 
 -- | Convert a lens to its van Laarhoven representation
 vanLaarhoven :: Functor f => Lens a b -> (b -> f b) -> (a -> f a)


### PR DESCRIPTION
Example expressions:

```
car ^. driver >. name >. first == "John"
```
```
car >. driver >. name >. first ~= "John"
```

I was surprised to see something like this wasn't present in this library, since, in my opinion, the most useful thing about lenses is the ability to compose them.